### PR TITLE
Change api to use connect option conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The `brotli.WithCompression` function will return an option that allow both clie
 ```go
 import "go.withmatt.com/connect-brotli"
 
-opts := brotli.New()
+opts := brotli.WithCompression()
 ```
 
 To enable client compression and force a specific method use `connect.WithSendCompression(brotli.Name)`.

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Compression is provided from the [github.com/andybalholm/brotli](https://github.
 
 # Usage
 
-The `brotli.New` function will return options that allow both client and servers to compress and decompress using brotli.
+The `brotli.New` function will return an option that allow both client and servers to compress and decompress using brotli.
 
 ```go
 import "go.withmatt.com/connect-brotli"
 
-clientOpts, serverOpts := brotli.New()
+opts := brotli.New()
 ```
 
 To enable client compression and force a specific method use `connect.WithSendCompression(brotli.Name)`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Compression is provided from the [github.com/andybalholm/brotli](https://github.
 
 # Usage
 
-The `brotli.New` function will return an option that allow both client and servers to compress and decompress using brotli.
+The `brotli.WithCompression` function will return an option that allow both client and servers to compress and decompress using brotli.
 
 ```go
 import "go.withmatt.com/connect-brotli"

--- a/connect_brotli.go
+++ b/connect_brotli.go
@@ -13,15 +13,15 @@ const (
 
 const Name = "br"
 
-// New returns client and handler options for the brotli compression method
+// WithCompression returns client and handler options for the brotli compression method
 // using the default compression level.
-func New() connect.Option {
-	return NewWithLevel(DefaultCompression)
+func WithCompression() connect.Option {
+	return WithCompressionLevel(DefaultCompression)
 }
 
-// NewWithLevel returns client and handler options for the brotli compression
+// WithCompressionLevel returns client and handler options for the brotli compression
 // method for your prefered compression level.
-func NewWithLevel(level int) connect.Option {
+func WithCompressionLevel(level int) connect.Option {
 	d, c := brComp(level)
 	return compressorOption{
 		ClientOption:  connect.WithAcceptCompression(Name, d, c),

--- a/connect_brotli.go
+++ b/connect_brotli.go
@@ -15,21 +15,29 @@ const Name = "br"
 
 // New returns client and handler options for the brotli compression method
 // using the default compression level.
-func New() (connect.ClientOption, connect.HandlerOption) {
+func New() connect.Option {
 	return NewWithLevel(DefaultCompression)
 }
 
 // NewWithLevel returns client and handler options for the brotli compression
 // method for your prefered compression level.
-func NewWithLevel(level int) (connect.ClientOption, connect.HandlerOption) {
+func NewWithLevel(level int) connect.Option {
 	d, c := brComp(level)
-	return connect.WithAcceptCompression(Name, d, c), connect.WithCompression(Name, d, c)
+	return compressorOption{
+		ClientOption:  connect.WithAcceptCompression(Name, d, c),
+		HandlerOption: connect.WithCompression(Name, d, c),
+	}
 }
 
 func brComp(level int) (func() connect.Decompressor, func() connect.Compressor) {
 	d := func() connect.Decompressor { return &brrWrapper{brotli.NewReader(nil)} }
 	c := func() connect.Compressor { return brotli.NewWriterLevel(nil, level) }
 	return d, c
+}
+
+type compressorOption struct {
+	connect.ClientOption
+	connect.HandlerOption
 }
 
 type brrWrapper struct{ *brotli.Reader }

--- a/example_test.go
+++ b/example_test.go
@@ -15,7 +15,7 @@ import (
 
 func ExampleNew() {
 	// Get client and server options
-	opts := brotli.New()
+	opts := brotli.WithCompression()
 
 	// Create a server.
 	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, opts)

--- a/example_test.go
+++ b/example_test.go
@@ -15,15 +15,15 @@ import (
 
 func ExampleNew() {
 	// Get client and server options
-	clientOpts, serverOpts := brotli.New()
+	opts := brotli.New()
 
 	// Create a server.
-	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, serverOpts)
+	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, opts)
 	srv := httptest.NewServer(h)
 	client := pingv1connect.NewPingServiceClient(
 		http.DefaultClient,
 		srv.URL,
-		clientOpts,
+		opts,
 		// Compress requests with Brotli.
 		connect.WithSendCompression(brotli.Name),
 	)


### PR DESCRIPTION
Hey!
Just opened up this pr with some changed that I think will bring the api a little closer to what connect-go uses.

Changes two things:
- `brotli.New` and `brotli.NewLevel` are renamed to `brotli.WithCompression` and `brotli.WithCompressionLevel` respectively to come closer to terminology used in connect-go around option naming.
- `brotli.WithCompression` and `brotli.WithCompressionLevel` returns a single `connect.Option` that can be passed into handler or client constructors.

Let me know what you think